### PR TITLE
`urllib.parse` instead of all `urllib`

### DIFF
--- a/PyInstaller/compat.py
+++ b/PyInstaller/compat.py
@@ -636,7 +636,7 @@ PY3_BASE_MODULES = {
     'tokenize',  # used by loader/pymod02_importers.py
     'traceback',  # for startup errors
     'types',
-    'urllib',  # dependency of pathlib
+    'urllib.parse',  # dependency of pathlib
     'weakref',
     'warnings',
 }


### PR DESCRIPTION
Tested in windows python 3.7.9 32bit.
Difference is huge: [before_and_after.zip](https://github.com/byehack/pyinstaller/files/12301499/before_and_after.zip)

The problem is base library doesn't contain `__init.__.py`

![image](https://github.com/byehack/pyinstaller/assets/26390254/1f172728-5832-45d9-a6ea-d2de6986d65e)

I think this is a bug and need to be fixed before merging this PR.
I can confirm that `urllib/__init__.py` is exists in pyz file (`build\app\PYZ-00.pyz`).